### PR TITLE
Hide selected item in select2. Fix an assignment bug when the top level ...

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -10,6 +10,8 @@ Version: 3.2 Timestamp: Mon Sep 10 10:38:04 PDT 2012
     vertical-align: top;
 	padding: 0;
 	border: 0;
+    /* force width to 100% */
+    width:100%\9;
 }
 /* To override styles found in Bootstrap3 */
 .select2-container:hover {
@@ -366,6 +368,10 @@ disabled look for already selected choices in the results dropdown
 }
 */
 .select2-results .select2-disabled {
+    display: none;
+}
+/* Hide selected items */ 
+.select2-results .select2-selected {
     display: none;
 }
 

--- a/select2.js
+++ b/select2.js
@@ -1789,7 +1789,16 @@ the specific language governing permissions and limitations under the Apache Lic
                             return equal(id, opts.id(el));
                         },
                         callback: !$.isFunction(callback) ? $.noop : function(filtered) {
-                            callback(filtered.results.length ? filtered.results[0] : null);
+			    if (filtered.results.length){
+                                var r1 = filtered.results[0];
+				//If we have two-level menu, and the top level can not be selected(no id), 
+				//we should return the children node to selected when only one child existed
+                                if (!r1.id && r1.children && r1.children.length === 1){
+                                    callback(r1.children[0]);
+                                }else{
+                                    callback(r1);
+                                }
+                            }
                         }
                     });
                 };


### PR DESCRIPTION
Hide selected item in select2.I think we should hide the item which has been selected.
If there are two level data and the top level can not be selected(not id attribute), when we call the the val() function  to select a item, the result will selected the top level in old code.
